### PR TITLE
[yocs_waypoint_provider] Normalized trajectory marker quaternions

### DIFF
--- a/yocs_waypoint_provider/src/waypoint_provider.cpp
+++ b/yocs_waypoint_provider/src/waypoint_provider.cpp
@@ -145,6 +145,7 @@ namespace yocs {
     marker.ns = "trajectories";
     marker.id = i + marker_index_;
     marker.pose = geometry_msgs::Pose();
+    marker.pose.orientation.w = 1; // normalize quaternion
     marker.type = visualization_msgs::Marker::LINE_STRIP;
     marker.action = visualization_msgs::Marker::ADD;
     marker.color.r = 0.0f;


### PR DESCRIPTION
[RVIZ reason](https://github.com/ros-visualization/rviz/commit/b3291453c75af65a4ef5606f5ae5ebe424b17f97)